### PR TITLE
Feat(NOISSUE): Added permalinks for headlines + light/darkmode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,25 @@
 site_name: Ansible - Good and Bad Practices
 site_url: https://T-Systems-MMS.github.io/ansible-bad-and-good-practices/
+markdown_extensions:
+  - toc:
+      permalink: true
 theme:
   name: material
+palette:
+  # Palette toggle for automatic mode
+  - media: "(prefers-color-scheme)"
+    toggle:
+      icon: material/brightness-auto
+      name: Switch to light mode
+  # Palette toggle for light mode
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+  # Palette toggle for dark mode
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to system preference


### PR DESCRIPTION
This PR adds some useful features for our Ansible code documentation:

- enables permalinks that you can copy the exact headlines within the URL (https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=permalin#table-of-contents)

- adds a light/dark mode + automatic mode discovery for newer browser versions (https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/?h=dark#automatic-light-dark-mode)
