### PR TITLE
Add note about limiting the gathered facts by subsets

### DIFF
--- a/docs/turn_off_gather_facts.md
+++ b/docs/turn_off_gather_facts.md
@@ -34,3 +34,20 @@ The collection of these facts is a time-consuming process and in order to speed 
 ```
 
 Keep in mind that you need to enable `gather_facts` if you want to use host-variables or want to collect information about the remote host. A list about some of these Ansible facts can be found here: https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html#ansible-facts
+It is also possible to limit the gathered subsets by using the [`ansible.builtin.setup`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html)
+
+## Example of limiting the gathered fact subsets
+
+```yaml
+---
+ - hosts: all
+   become: true
+   gather_facts: false
+   tasks:
+     - name: gather only distribution facts
+       ansible.builtin.setup:
+       gather_subset:
+         - '!all'
+         - '!min'
+         - distribution
+```

--- a/docs/turn_off_gather_facts.md
+++ b/docs/turn_off_gather_facts.md
@@ -34,7 +34,8 @@ The collection of these facts is a time-consuming process and in order to speed 
 ```
 
 Keep in mind that you need to enable `gather_facts` if you want to use host-variables or want to collect information about the remote host. A list about some of these Ansible facts can be found here: https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html#ansible-facts
-It is also possible to limit the gathered subsets by using the [`ansible.builtin.setup`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html)
+
+It is also possible to limit the gathered subsets by using the [`ansible.builtin.setup`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html) module.
 
 ## Example of limiting the gathered fact subsets
 


### PR DESCRIPTION
This will add a note about using the `ansible.builtin.setup` module to limit the gathered facts in case you just need a small subset of the facts.